### PR TITLE
Rename sortable to sortableWidgets

### DIFF
--- a/assets/files/js/jquery.binding.js
+++ b/assets/files/js/jquery.binding.js
@@ -26,7 +26,7 @@
    * @param   {..*}           [args]
    * @returns {jQuery|*}
    */
-  $.fn.sortable = function (options) {
+  $.fn.sortableWidgets = function (options) {
     var retVal;
 
     this.each(function () {

--- a/assets/files/js/sortable-widgets.js
+++ b/assets/files/js/sortable-widgets.js
@@ -1,5 +1,5 @@
 function initSortableWidgets() {
-  $('[data-sortable-widget=1] tbody').sortable({
+  $('[data-sortable-widget=1] tbody').sortableWidgets({
     animation: 300,
     handle: '.sortable-widget-handler',
     dataIdAttr: 'data-sortable-id',


### PR DESCRIPTION
Это исправляет проблему с вызовом onEnd() при наличии другого sortable.

Также одним из фиксов был этого -- https://github.com/kotchuprik/yii2-sortable-widgets/pull/10, но на нескольких гридах фикс не работал.

P.S. Не знаю, насколько правильным является замена sortable на sortableWidgets в стандартной библиотеке [RubaXa/Sortable/jquery.binding.js](https://github.com/RubaXa/Sortable/blob/master/jquery.binding.js) , но это работает =)
