### PR TITLE
add new property startOrder and fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,36 @@ public function actions()
 }
 ```
 
+If you're using another order field not 'order' (example 'sortingFieldName'), you must specify it in 'orderAttribute' parameter:
+
+```php
+public function actions()
+{
+    return [
+        'sorting' => [
+            'class' => \kotchuprik\sortable\actions\Sorting::className(),
+            'query' => \vendor\namespace\Model::find(),
+            'orderAttribute' => 'sortingFieldName',
+        ],
+    ];
+}
+```
+
+If you're need start ordering not 0 you must specify it in 'startOrder' parameter:
+
+```php
+public function actions()
+{
+    return [
+        'sorting' => [
+            'class' => \kotchuprik\sortable\actions\Sorting::className(),
+            'query' => \vendor\namespace\Model::find(),           
+            'startOrder' => 1
+        ],
+    ];
+}
+```
+
 If you're using another primary key (not 'id'), you must specify it in 'pk' parameter:
 
 ```php

--- a/actions/Sorting.php
+++ b/actions/Sorting.php
@@ -16,7 +16,10 @@ class Sorting extends Action
 
     /** @var string */
     public $pk = 'id';
-    
+
+    /** @var int */
+    public $startOrder = 0;
+
     public function run()
     {
         $transaction = \Yii::$app->db->beginTransaction();
@@ -28,7 +31,7 @@ class Sorting extends Action
                 if ($model === null) {
                     throw new BadRequestHttpException();
                 }
-                $model->{$this->orderAttribute} = $offset + $order;
+                $model->{$this->orderAttribute} = $offset + $order + $this->startOrder;
                 $model->update(false, [$this->orderAttribute]);
             }
             $transaction->commit();


### PR DESCRIPTION
Сейчас если перетаскивать строки в gridview сортировка начинается с 0.
Предлагаю добавить свойство startOrder чтобы менять это поведение.

Add new property 'startOrder'   if need change number of first element for order column.